### PR TITLE
Bare minimum expected changes for correct Pipeline behavior

### DIFF
--- a/tekton/setup/tasks/execute-maven-task.yaml
+++ b/tekton/setup/tasks/execute-maven-task.yaml
@@ -168,6 +168,9 @@ spec:
 
       securityContext:
         privileged: false
+        # From my test environment, this container was able to find the `settings.xml` file without issue,
+        # so there was no need to apply this modification:
+        # runAsUser: 1001
     - args:
         - '-s'
         - $(workspaces.maven-settings.path)/settings.xml
@@ -179,6 +182,8 @@ spec:
       resources: {}
       securityContext:
         privileged: false
+        # This was the only truly required change I found to have my test environment's pipeline to run correctly
+        runAsUser: 1001
       volumeMounts:
         - mountPath: /certs/client
           name: dind-certs

--- a/tekton/setup/tasks/get-source-with-git-task.yaml
+++ b/tekton/setup/tasks/get-source-with-git-task.yaml
@@ -53,6 +53,9 @@ spec:
     - name: git-clone
       # run the container as non root user
       securityContext:
+        # NOTE: it may also be possible to modify just this value instead of the UID in the execute-maven-task Task,
+        # but this would also depend on the baseline image; I didn't check this, as it's simpler to work with this UID
+        # in both of the other images than the other way round.
         runAsUser: 1001
       workingDir: /workspace
       image: $(params.GIT_BASE_IMAGE)


### PR DESCRIPTION
As requested: tiny PR highlighting the changes that resolved the issue with the differing maven images. Minor notes on changes included.

These are the minimum changes I'd expect to correct the behavior of the pipeline as it is with the GCR & RH images. My expectation, as mentioned previously, is that the issue is a filesystem permissions one. With that being the case, there may be _more_ necessary changes than these, but this is what I'd expect to be applied in all circumstances.

For more key details, feel free to reach out over the case.